### PR TITLE
Add PgconfigPublishedInfoRepository and materialized tables

### DIFF
--- a/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/backend/pgconfig/catalog/PgconfigCatalogFacade.java
+++ b/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/backend/pgconfig/catalog/PgconfigCatalogFacade.java
@@ -6,9 +6,15 @@ package org.geoserver.cloud.backend.pgconfig.catalog;
 
 import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
+import java.util.stream.Stream;
 import lombok.NonNull;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogInfo;
+import org.geoserver.catalog.PublishedInfo;
+import org.geoserver.catalog.plugin.CatalogInfoRepository;
+import org.geoserver.catalog.plugin.CatalogInfoRepository.LayerGroupRepository;
+import org.geoserver.catalog.plugin.CatalogInfoRepository.LayerRepository;
+import org.geoserver.catalog.plugin.Query;
 import org.geoserver.catalog.plugin.RepositoryCatalogFacadeImpl;
 import org.geoserver.catalog.plugin.resolving.CatalogPropertyResolver;
 import org.geoserver.catalog.plugin.resolving.CollectionPropertiesInitializer;
@@ -17,26 +23,65 @@ import org.geoserver.cloud.backend.pgconfig.catalog.repository.PgconfigCatalogIn
 import org.geoserver.cloud.backend.pgconfig.catalog.repository.PgconfigLayerGroupRepository;
 import org.geoserver.cloud.backend.pgconfig.catalog.repository.PgconfigLayerRepository;
 import org.geoserver.cloud.backend.pgconfig.catalog.repository.PgconfigNamespaceRepository;
+import org.geoserver.cloud.backend.pgconfig.catalog.repository.PgconfigPublishedInfoReadOnlyRepository;
 import org.geoserver.cloud.backend.pgconfig.catalog.repository.PgconfigResourceRepository;
 import org.geoserver.cloud.backend.pgconfig.catalog.repository.PgconfigStoreRepository;
 import org.geoserver.cloud.backend.pgconfig.catalog.repository.PgconfigStyleRepository;
 import org.geoserver.cloud.backend.pgconfig.catalog.repository.PgconfigWorkspaceRepository;
+import org.geotools.api.filter.Filter;
+import org.geotools.filter.visitor.SimplifyingFilterVisitor;
 import org.springframework.jdbc.core.JdbcTemplate;
 
 /**
+ * A facade for the catalog in the {@code pgconfig} backend of GeoServer Cloud.
+ * This class leverages a PostgreSQL database via a
+ * {@link JdbcTemplate} to persist and retrieve catalog data.
+ * <p>
+ * Repositories are initialized in the constructor using the provided {@link JdbcTemplate}.
+ * A notable feature is the inclusion of a dedicated, read-only {@link PublishedInfo} repository
+ * ({@link PgconfigPublishedInfoReadOnlyRepository}), which optimizes queries for published
+ * information (combining {@link LayerInfo} and {@link LayerGroupInfo}) without requiring separate
+ * queries to layer and layer group repositories.
+ * <p>
+ * <strong>Key Features:</strong>
+ * <ul>
+ *   <li>Efficient querying of {@link PublishedInfo} using a dedicated read-only repository.</li>
+ *   <li>Automatic resolution of outbound catalog properties via a {@link UnaryOperator}, applied to all
+ *       repositories during catalog setup.</li>
+ * </ul>
+ * <p>
+ * This class overrides specific methods from {@link RepositoryCatalogFacadeImpl} to utilize the
+ * {@link PgconfigPublishedInfoReadOnlyRepository} directly for counting and querying
+ * {@link PublishedInfo} objects. This approach enhances performance by avoiding multiple queries
+ * and merge-sorting of results, as done in the default implementation.
+ * <p>
+ * <strong>Usage Note:</strong> The {@link PublishedInfo} repository is read-only and intended for
+ * querying purposes only. Modifications to catalog data should be performed through the
+ * appropriate writable repositories (e.g., {@link PgconfigLayerRepository} or
+ * {@link PgconfigLayerGroupRepository}).
+ *
+ * @see PgconfigPublishedInfoReadOnlyRepository
+ * @see RepositoryCatalogFacadeImpl
+ * @see JdbcTemplate
  * @since 1.4
  */
 public class PgconfigCatalogFacade extends RepositoryCatalogFacadeImpl {
+    /**
+     * Read-only {@link PublishedInfo} repository, used to query published without having to perform
+     * two queries (one for layers and one for layer groups) and them merge-sort the results.
+     * @see #queryPublishedInfo(Query)
+     */
+    private PgconfigPublishedInfoReadOnlyRepository publishedInfoReadOnlyRepo;
 
     public PgconfigCatalogFacade(@NonNull JdbcTemplate template) {
-        PgconfigNamespaceRepository namespaces = new PgconfigNamespaceRepository(template);
-        PgconfigWorkspaceRepository workspaces = new PgconfigWorkspaceRepository(template);
-        PgconfigStyleRepository styles = new PgconfigStyleRepository(template);
+        var namespaces = new PgconfigNamespaceRepository(template);
+        var workspaces = new PgconfigWorkspaceRepository(template);
+        var styles = new PgconfigStyleRepository(template);
 
-        PgconfigStoreRepository stores = new PgconfigStoreRepository(template);
-        PgconfigLayerRepository layers = new PgconfigLayerRepository(template, styles);
-        PgconfigResourceRepository resources = new PgconfigResourceRepository(template, layers);
-        PgconfigLayerGroupRepository layerGroups = new PgconfigLayerGroupRepository(template);
+        var stores = new PgconfigStoreRepository(template);
+        var layers = new PgconfigLayerRepository(template, styles);
+        var resources = new PgconfigResourceRepository(template, layers);
+        var layerGroups = new PgconfigLayerGroupRepository(template, styles);
 
         super.setNamespaceRepository(namespaces);
         super.setWorkspaceRepository(workspaces);
@@ -45,12 +90,30 @@ public class PgconfigCatalogFacade extends RepositoryCatalogFacadeImpl {
         super.setLayerRepository(layers);
         super.setLayerGroupRepository(layerGroups);
         super.setStyleRepository(styles);
+        /*
+         * We have a PublishedInfo repository, despite not being common practice (since
+         * PublishedInfo was introduced later as a superclass for LayerInfo and
+         * LayerGroupInfo, it never had its own "repository" in the default
+         * Catalog/Facade implementation)
+         */
+        this.publishedInfoReadOnlyRepo = new PgconfigPublishedInfoReadOnlyRepository(template, styles);
     }
 
     @Override
     public void setCatalog(Catalog catalog) {
         super.setCatalog(catalog);
         setOutboundResolver();
+    }
+
+    /**
+     * Queries {@link PgconfigPublishedInfoReadOnlyRepository} directly. The default implementation will
+     * query {@link LayerRepository} and {@link LayerGroupRepository} separately.
+     */
+    @Override
+    protected int countPublishedInfo(Filter filter) {
+        PgconfigPublishedInfoReadOnlyRepository repo = this.publishedInfoReadOnlyRepo;
+        Filter simplified = SimplifyingFilterVisitor.simplify(filter);
+        return (int) repo.count(PublishedInfo.class, simplified);
     }
 
     @SuppressWarnings("unchecked")
@@ -66,5 +129,31 @@ public class PgconfigCatalogFacade extends RepositoryCatalogFacadeImpl {
         return CatalogPropertyResolver.<T>of(catalog)
                 .andThen(ResolvingProxyResolver.<T>of(catalog))
                 .andThen(CollectionPropertiesInitializer.instance())::apply;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T extends CatalogInfo, R extends CatalogInfoRepository<T>> R repository(Class<T> of) {
+        if (PublishedInfo.class.equals(of)) {
+            return (R) publishedInfoReadOnlyRepo;
+        }
+        return repositories.repository(of);
+    }
+
+    @Override
+    public <T extends CatalogInfo, R extends CatalogInfoRepository<T>> R repositoryFor(T info) {
+        return repositories.repositoryFor(info);
+    }
+
+    /**
+     * Queries {@link PgconfigPublishedInfoReadOnlyRepository} directly. The default implementation will
+     * query {@link LayerRepository} and {@link LayerGroupRepository}, returning
+     * a merge-sorted stream.
+     */
+    @Override
+    protected Stream<PublishedInfo> queryPublishedInfo(Query<PublishedInfo> query) {
+        final Filter filter = SimplifyingFilterVisitor.simplify(query.getFilter());
+
+        return this.publishedInfoReadOnlyRepo.findAll(query.withFilter(filter));
     }
 }

--- a/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/backend/pgconfig/catalog/repository/LRUCache.java
+++ b/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/backend/pgconfig/catalog/repository/LRUCache.java
@@ -1,0 +1,54 @@
+package org.geoserver.cloud.backend.pgconfig.catalog.repository;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * A Least Recently Used (LRU) cache implementation using {@link LinkedHashMap}.
+ * This cache evicts the least recently used entry when the cache size exceeds the
+ * specified maximum capacity.
+ *
+ * <p>
+ * This implementation leverages the {@link LinkedHashMap} with access order
+ * enabled ({@code accessOrder = true}), which automatically moves entries to the
+ * end of the list upon access (get or put), making the beginning of the list the
+ * least recently used entry.
+ * </p>
+ *
+ * <p>
+ * The cache is initialized with a maximum capacity, and once this capacity is
+ * exceeded, the least recently used entry is automatically removed.
+ * </p>
+ *
+ * @param <K> the type of keys maintained by this cache
+ * @param <V> the type of mapped values
+ */
+@SuppressWarnings({"serial", "java:S2160"})
+class LRUCache<K, V> extends LinkedHashMap<K, V> {
+    /** The maximum number of entries allowed in the cache */
+    private final int maxCapacity;
+
+    /**
+     * Constructs an LRU cache with the specified maximum capacity.
+     *
+     * @param maxCapacity the maximum number of entries allowed in the cache
+     */
+    public LRUCache(int maxCapacity) {
+        // Initialize LinkedHashMap with capacity, load factor 0.75, and access order enabled
+        super(maxCapacity, 0.75f, true);
+        this.maxCapacity = maxCapacity;
+    }
+
+    /**
+     * Determines whether the eldest entry should be removed.
+     * This method is called after a put operation and removes the eldest entry
+     * if the cache size exceeds the maximum capacity.
+     *
+     * @param eldest the eldest entry (least recently used)
+     * @return true if the eldest entry should be removed, false otherwise
+     */
+    @Override
+    protected boolean removeEldestEntry(Map.Entry<K, V> eldest) {
+        return size() > maxCapacity;
+    }
+}

--- a/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/backend/pgconfig/catalog/repository/PgconfigLayerRepository.java
+++ b/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/backend/pgconfig/catalog/repository/PgconfigLayerRepository.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 import java.util.stream.Stream;
 import lombok.NonNull;
 import org.geoserver.catalog.LayerInfo;
+import org.geoserver.catalog.Predicates;
 import org.geoserver.catalog.ResourceInfo;
 import org.geoserver.catalog.StyleInfo;
 import org.geoserver.catalog.plugin.CatalogInfoRepository.LayerRepository;
@@ -19,54 +20,51 @@ import org.springframework.jdbc.core.RowMapper;
 /**
  * @since 1.4
  */
-public class PgconfigLayerRepository extends PgconfigCatalogInfoRepository<LayerInfo> implements LayerRepository {
-
-    private final PgconfigStyleRepository styleLoader;
+public class PgconfigLayerRepository extends PgconfigPublishedInfoRepository<LayerInfo> implements LayerRepository {
 
     /**
      * @param template
      */
     public PgconfigLayerRepository(@NonNull JdbcTemplate template, @NonNull PgconfigStyleRepository styleLoader) {
-        super(template);
-        this.styleLoader = styleLoader;
+        super(LayerInfo.class, template, styleLoader);
     }
 
     @Override
-    public Class<LayerInfo> getContentType() {
-        return LayerInfo.class;
+    protected String getReturnColumns() {
+        return CatalogInfoRowMapper.LAYERINFO_BUILD_COLUMNS;
     }
 
     @Override
-    protected String getQueryTable() {
-        return "layerinfos";
+    protected final RowMapper<LayerInfo> newRowMapper() {
+        return CatalogInfoRowMapper.<LayerInfo>newInstance().setStyleLoader(styleRepo::findById);
     }
 
     @Override
     public Optional<LayerInfo> findOneByName(@NonNull String possiblyPrefixedName) {
         String sql =
                 """
-                SELECT publishedinfo, resource, store, workspace, namespace, "defaultStyle" \
-                FROM layerinfos \
-                WHERE "%s" = ?
+                SELECT "@type", publishedinfo, resource, store, workspace, namespace, "defaultStyle" \
+                FROM %s \
+                WHERE "@type" = 'LayerInfo' AND "%s" = ?
                 """;
         if (possiblyPrefixedName.contains(":")) {
             // two options here, it's either a prefixed name like in <workspace>:<name>, or the
             // ResourceInfo name actually contains a colon
-            Optional<LayerInfo> found = findOne(sql.formatted("prefixedName"), possiblyPrefixedName);
+            Optional<LayerInfo> found = findOne(sql.formatted(getQueryTable(), "prefixedName"), possiblyPrefixedName);
             if (found.isPresent()) return found;
         }
 
         // no colon in name or name actually contains a colon
-        return findOne(sql.formatted("name"), possiblyPrefixedName);
+        return findOne(sql.formatted(getQueryTable(), "name"), possiblyPrefixedName);
     }
 
     @Override
     public Stream<LayerInfo> findAllByDefaultStyleOrStyles(@NonNull StyleInfo style) {
-        var ff = FILTER_FACTORY;
-        Filter filter = ff.or(
-                ff.equals(ff.property("defaultStyle.id"), ff.literal(style.getId())),
-                ff.equals(ff.property("styles.id"), ff.literal(style.getId())));
+        Filter typeFilter = Predicates.isInstanceOf(LayerInfo.class);
+        Filter styleFilter = Predicates.or(
+                Predicates.equal("defaultStyle.id", style.getId()), Predicates.equal("styles.id", style.getId()));
 
+        Filter filter = Predicates.and(typeFilter, styleFilter);
         return findAll(Query.valueOf(LayerInfo.class, filter));
     }
 
@@ -74,15 +72,11 @@ public class PgconfigLayerRepository extends PgconfigCatalogInfoRepository<Layer
     public Stream<LayerInfo> findAllByResource(@NonNull ResourceInfo resource) {
         String sql =
                 """
-                SELECT publishedinfo, resource, store, workspace, namespace, "defaultStyle" \
-                FROM layerinfos \
-                WHERE "resource.id" = ?
-                """;
+                SELECT "@type", publishedinfo, resource, store, workspace, namespace, "defaultStyle" \
+                FROM %s \
+                WHERE "@type" = 'LayerInfo' AND "resource.id" = ?
+                """
+                        .formatted(getQueryTable());
         return super.queryForStream(sql, resource.getId());
-    }
-
-    @Override
-    protected RowMapper<LayerInfo> newRowMapper() {
-        return CatalogInfoRowMapper.layer(styleLoader::findById);
     }
 }

--- a/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/backend/pgconfig/catalog/repository/PgconfigPublishedInfoReadOnlyRepository.java
+++ b/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/backend/pgconfig/catalog/repository/PgconfigPublishedInfoReadOnlyRepository.java
@@ -1,0 +1,51 @@
+/*
+ * (c) 2025 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.backend.pgconfig.catalog.repository;
+
+import lombok.NonNull;
+import org.geoserver.catalog.PublishedInfo;
+import org.geoserver.catalog.plugin.Patch;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+
+public class PgconfigPublishedInfoReadOnlyRepository extends PgconfigPublishedInfoRepository<PublishedInfo> {
+
+    public PgconfigPublishedInfoReadOnlyRepository(
+            @NonNull JdbcTemplate template, @NonNull PgconfigStyleRepository styleLoader) {
+
+        super(PublishedInfo.class, template, styleLoader);
+    }
+
+    @Override
+    protected String getReturnColumns() {
+        return CatalogInfoRowMapper.PUBLISHEDINFO_BUILD_COLUMNS;
+    }
+
+    @Override
+    protected final RowMapper<PublishedInfo> newRowMapper() {
+        return CatalogInfoRowMapper.<PublishedInfo>newInstance().setStyleLoader(styleRepo::findById);
+    }
+
+    @Override
+    public void add(@NonNull PublishedInfo value) {
+        throwUnsupported();
+    }
+
+    @Override
+    public void remove(@NonNull PublishedInfo value) {
+        throwUnsupported();
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public PublishedInfo update(@NonNull PublishedInfo value, @NonNull Patch patch) {
+        throw throwUnsupported();
+    }
+
+    private UnsupportedOperationException throwUnsupported() {
+        throw new UnsupportedOperationException(
+                "%s is read-only".formatted(getClass().getSimpleName()));
+    }
+}

--- a/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/backend/pgconfig/catalog/repository/PgconfigPublishedInfoRepository.java
+++ b/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/backend/pgconfig/catalog/repository/PgconfigPublishedInfoRepository.java
@@ -1,0 +1,42 @@
+/*
+ * (c) 2024 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.backend.pgconfig.catalog.repository;
+
+import static org.geoserver.catalog.Predicates.and;
+import static org.geoserver.catalog.Predicates.isInstanceOf;
+
+import lombok.NonNull;
+import org.geoserver.catalog.Info;
+import org.geoserver.catalog.PublishedInfo;
+import org.geotools.api.filter.Filter;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * @since 2.27.0.0
+ */
+public abstract class PgconfigPublishedInfoRepository<P extends PublishedInfo>
+        extends PgconfigCatalogInfoRepository<P> {
+
+    protected final PgconfigStyleRepository styleRepo;
+
+    protected PgconfigPublishedInfoRepository(
+            @NonNull Class<P> type, @NonNull JdbcTemplate template, @NonNull PgconfigStyleRepository styleLoader) {
+        super(type, template);
+        this.styleRepo = styleLoader;
+    }
+
+    @Override
+    protected final String getQueryTable() {
+        return "publishedinfos";
+    }
+
+    @Override
+    protected <S extends Info> Filter applyTypeFilter(Filter filter, Class<S> type) {
+        if (!PublishedInfo.class.equals(type)) {
+            filter = and(isInstanceOf(type), filter);
+        }
+        return filter;
+    }
+}

--- a/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/backend/pgconfig/catalog/repository/PgconfigPublishedInfoRepository.java
+++ b/src/catalog/backends/pgconfig/src/main/java/org/geoserver/cloud/backend/pgconfig/catalog/repository/PgconfigPublishedInfoRepository.java
@@ -27,9 +27,12 @@ public abstract class PgconfigPublishedInfoRepository<P extends PublishedInfo>
         this.styleRepo = styleLoader;
     }
 
+    /**
+     * @return {@code publishedinfos_mat}, the materialized table maintained by triggers for fast querying of {@link PublishedInfo}s
+     */
     @Override
     protected final String getQueryTable() {
-        return "publishedinfos";
+        return "publishedinfos_mat";
     }
 
     @Override

--- a/src/catalog/backends/pgconfig/src/main/resources/db/pgconfig/migration/postgresql/V1_8_1__Revert_Catalog_Full_Text_Search_Indexes.sql
+++ b/src/catalog/backends/pgconfig/src/main/resources/db/pgconfig/migration/postgresql/V1_8_1__Revert_Catalog_Full_Text_Search_Indexes.sql
@@ -1,0 +1,13 @@
+-- Drop indexes created in V1_2__Catalog_Full_Text_Search.sql as they're not used
+-- We'll address the full text search capability in a future iteration accounting for
+-- both the database schema and code changes required.
+
+DROP INDEX IF EXISTS namespaceinfo_to_tsvector_idx;
+DROP INDEX IF EXISTS workspaceinfo_to_tsvector_idx;
+DROP INDEX IF EXISTS storeinfo_to_tsvector_idx;
+DROP INDEX IF EXISTS resourceinfo_to_tsvector_idx;
+DROP INDEX IF EXISTS layerinfo_to_tsvector_idx;
+DROP INDEX IF EXISTS layergroupinfo_to_tsvector_idx;
+DROP INDEX IF EXISTS styleinfo_to_tsvector_idx;
+
+

--- a/src/catalog/backends/pgconfig/src/main/resources/db/pgconfig/migration/postgresql/V1_9_0__PublishedInfos_add_styles_id_and_layers_id.sql
+++ b/src/catalog/backends/pgconfig/src/main/resources/db/pgconfig/migration/postgresql/V1_9_0__PublishedInfos_add_styles_id_and_layers_id.sql
@@ -1,0 +1,100 @@
+/*
+ * Add styles.id TEXT[] and layers.id TEXT[] columns to the publishedinfos view 
+ */
+DROP VIEW tilelayers;
+DROP VIEW publishedinfos;
+CREATE OR REPLACE VIEW publishedinfos
+AS
+  SELECT 
+    -- common PublishedInfo properties
+         id, "@type", name, "prefixedName", title, enabled, advertised, "type", workspace, publishedinfo, "styles.id",
+    -- LayerInfo specific properties
+         "resource.id",
+         "resource.name",
+         "resource.enabled",
+         "resource.advertised",
+         "resource.SRS",
+         "resource.store.id",
+         "resource.store.name",
+         "resource.store.enabled",
+         "resource.store.type",
+         "resource.store.workspace.id",
+         "resource.store.workspace.name",
+         "resource.namespace.id",
+         "resource.namespace.prefix",
+         "defaultStyle.id",
+         "defaultStyle.name",
+         "defaultStyle.filename",
+         "defaultStyle.format",
+         resource,
+         store,
+         namespace,
+         "defaultStyle",
+    -- LayerGroupInfo specific properties
+         NULL AS mode,
+         NULL AS "workspace.id",
+         NULL AS "workspace.name",
+         NULL AS "layers.id"
+  FROM layerinfos
+UNION
+  SELECT 
+    -- common PublishedInfo properties
+         id, "@type", name, "prefixedName", title, enabled, advertised, "type", workspace, publishedinfo, "styles.id",
+    -- LayerInfo specific properties
+         NULL AS "resource.id",
+         NULL AS "resource.name",
+         NULL AS "resource.enabled",
+         NULL AS "resource.advertised",
+         NULL AS "resource.SRS",
+         NULL AS "resource.store.id",
+         NULL AS "resource.store.name",
+         NULL AS "resource.store.enabled",
+         NULL AS "resource.store.type",
+         NULL AS "resource.store.workspace.id",
+         NULL AS "resource.store.workspace.name",
+         NULL AS "resource.namespace.id",
+         NULL AS "resource.namespace.prefix",
+         NULL AS "defaultStyle.id",
+         NULL AS "defaultStyle.name",
+         NULL AS "defaultStyle.filename",
+         NULL AS "defaultStyle.format",
+         NULL AS resource,
+         NULL AS store,
+         NULL AS namespace,
+         NULL AS "defaultStyle",
+    -- LayerGroupInfo specific properties
+         mode,
+         "workspace.id",
+         "workspace.name",
+         "layers.id"
+  FROM layergroupinfos;
+
+/*
+ * re-create tilelayers
+ */  
+CREATE OR REPLACE VIEW tilelayers
+AS
+  SELECT
+    -- queryable fields
+	p."id",
+	p."@type",
+	v."prefixedName" AS name,
+	v.enabled,
+	v.advertised,
+	v."type",
+	CASE
+		WHEN v."workspace.id" IS NOT NULL THEN v."workspace.name"
+		WHEN v."workspace.id" IS NULL THEN v."resource.store.workspace.name"
+	END AS "workspace.name",
+	p.name AS "published.name",
+	-- jsonb fields, required to get the tilelayer and its publishedinfo in full
+	p.tilelayer,
+	v.workspace,
+	v.namespace,
+	v.store,
+	v.resource,
+	p.info as publishedinfo,
+	v."defaultStyle"
+	FROM publishedinfo p
+	INNER JOIN publishedinfos v ON p.id = v.id
+	WHERE p.tilelayer IS NOT NULL;

--- a/src/catalog/backends/pgconfig/src/main/resources/db/pgconfig/migration/postgresql/V2_0_0__PublishedInfos_Materialized_Table.sql
+++ b/src/catalog/backends/pgconfig/src/main/resources/db/pgconfig/migration/postgresql/V2_0_0__PublishedInfos_Materialized_Table.sql
@@ -1,0 +1,353 @@
+-- V2_0_0__PublishedInfos_Materialized_Table.sql
+-- @since 2.27.0.0
+
+/*
+ * Purpose:
+ * Creates and indexes the publishedinfos_mat and tilelayers_mat materialized tables, and
+ * establishes triggers to keep them synchronized with changes to layerinfo, layergroupinfo,
+ * workspaceinfo, namespaceinfo, storeinfo, resourceinfo, and styleinfo. This ensures real-time
+ * consistency with the publishedinfos and tilelayers views.
+ *
+ * Table Initialization and Indexing:
+ * - publishedinfos_mat and tilelayers_mat are initialized using SELECT * INTO from their
+ *   respective views (publishedinfos and tilelayers).
+ * - Indexes are created to optimize query performance on common fields (e.g., id, @type, name)
+ *   and array fields (e.g., styles.id, layers.id) using GIN indexes where applicable.
+ * - Partial indexes (e.g., WHERE column IS NOT NULL) are used for columns with high NULL
+ *   prevalence (e.g., mode, workspace.id) to reduce size and improve selectivity.
+ *
+ * tilelayers_mat Synchronization:
+ * tilelayers_mat syncs from publishedinfos_mat instead of directly from publishedinfo or other
+ * base tables for several reasons:
+ * 1. Dependency: Tile layers (tilelayers_mat) are a filtered subset of published infos
+ *    (publishedinfos_mat), defined by a non-NULL tilelayer column in publishedinfo. Syncing
+ *    from publishedinfos_mat ensures consistency and reuses existing logic.
+ * 2. Simplified Maintenance: A single trigger on publishedinfos_mat avoids duplicating logic
+ *    across multiple base tables (e.g., layerinfo, layergroupinfo).
+ * 3. Future Scalability: Updates to publishedinfos_mat from additional CatalogInfo objects
+ *    (e.g., workspaces, namespaces) automatically propagate to tilelayers_mat.
+ * 4. Efficiency: Minimal overhead given the low number of layer groups and tile layers,
+ *    avoiding data duplication in publishedinfos_mat.
+ *
+ * Trigger Logic:
+ * - A shared function, sync_publishedinfos_by_ids, updates publishedinfos_mat for a given set
+ *   of publishedinfo IDs.
+ * - Triggers on layerinfo and layergroupinfo handle INSERT, UPDATE, DELETE to sync
+ *   publishedinfos_mat directly.
+ * - Triggers on workspaceinfo, namespaceinfo, storeinfo, resourceinfo handle UPDATE, while
+ *   styleinfo handles UPDATE and DELETE, reflecting application logic where INSERT and DELETE
+ *   are managed separately.
+ * - The publishedinfos_mat trigger syncs tilelayers_mat based on changes to its rows.
+ *
+ * Index Cleanup:
+ * - Drops unneeded indexes from publishedinfo (enabled_idx, advertised_idx, info_idx if exists),
+ *   layerinfo (name_idx, has_tilelayer, styles_gin_idx, to_tsvector_idx, type_idx), and
+ *   layergroupinfo (enabled_idx, advertised_idx, name_idx, has_tilelayer, layers_gin_idx,
+ *   styles_gin_idx, to_tsvector_idx, type_idx) as queries now use publishedinfos_mat and
+ *   tilelayers_mat, reducing write overhead without impacting query performance.
+ * - Retains primary keys, foreign key indexes (e.g., resource_idx, workspace_idx), and unique
+ *   constraints (e.g., resource_name_key, workspace_name_key) for triggers and integrity.
+ *
+ * Why This Strategy:
+ * - Efficiency: Triggers are tailored to application behavior (e.g., no INSERT/DELETE for most
+ *   CatalogInfo tables due to prior publishedinfo management).
+ * - Simplicity: Centralized sync logic reduces code duplication.
+ * - Safety: Styleinfo DELETE trigger ensures consistency for edge cases.
+ * - Real-Time Updates: Immediate synchronization supports querying needs.
+ *
+ * Note: The @type column is excluded from updates in publishedinfos_mat triggers since it is
+ * immutable, set as 'LayerInfo' or 'LayerGroupInfo' based on the source table.
+ */
+
+-- Drop existing tables if they exist to ensure a clean slate
+DROP TABLE IF EXISTS publishedinfos_mat;
+DROP TABLE IF EXISTS tilelayers_mat;
+
+-- Create and populate tables from their respective views
+SELECT * INTO publishedinfos_mat FROM publishedinfos;
+SELECT * INTO tilelayers_mat FROM tilelayers;
+
+-- Add primary key constraints
+ALTER TABLE publishedinfos_mat ADD PRIMARY KEY (id);
+ALTER TABLE tilelayers_mat ADD PRIMARY KEY (id);
+
+-- Indexes for publishedinfos_mat (30 indexes with partials)
+CREATE INDEX publishedinfos_mat_id_idx ON publishedinfos_mat ("id");
+CREATE INDEX publishedinfos_mat_infotype_idx ON publishedinfos_mat ("@type");
+CREATE INDEX publishedinfos_mat_name_idx ON publishedinfos_mat (name);
+CREATE INDEX publishedinfos_mat_prefixedname_idx ON publishedinfos_mat ("prefixedName");
+CREATE INDEX publishedinfos_mat_title_idx ON publishedinfos_mat (title);
+CREATE INDEX publishedinfos_mat_enabled_idx ON publishedinfos_mat (enabled);
+CREATE INDEX publishedinfos_mat_advertised_idx ON publishedinfos_mat (advertised);
+CREATE INDEX publishedinfos_mat_type_idx ON publishedinfos_mat ("type");
+CREATE INDEX publishedinfos_mat_resource_id_idx ON publishedinfos_mat ("resource.id");
+CREATE INDEX publishedinfos_mat_resource_name_idx ON publishedinfos_mat ("resource.name");
+CREATE INDEX publishedinfos_mat_resource_enabled_idx ON publishedinfos_mat ("resource.enabled");
+CREATE INDEX publishedinfos_mat_resource_advertised_idx ON publishedinfos_mat ("resource.advertised");
+CREATE INDEX publishedinfos_mat_resource_srs_idx ON publishedinfos_mat ("resource.SRS");
+CREATE INDEX publishedinfos_mat_resource_store_id_idx ON publishedinfos_mat ("resource.store.id");
+CREATE INDEX publishedinfos_mat_resource_store_name_idx ON publishedinfos_mat ("resource.store.name");
+CREATE INDEX publishedinfos_mat_resource_store_enabled_idx ON publishedinfos_mat ("resource.store.enabled");
+CREATE INDEX publishedinfos_mat_resource_store_type_idx ON publishedinfos_mat ("resource.store.type");
+CREATE INDEX publishedinfos_mat_resource_store_workspace_id_idx ON publishedinfos_mat ("resource.store.workspace.id");
+CREATE INDEX publishedinfos_mat_resource_store_workspace_name_idx ON publishedinfos_mat ("resource.store.workspace.name");
+CREATE INDEX publishedinfos_mat_resource_namespace_id_idx ON publishedinfos_mat ("resource.namespace.id");
+CREATE INDEX publishedinfos_mat_resource_namespace_prefix_idx ON publishedinfos_mat ("resource.namespace.prefix");
+CREATE INDEX publishedinfos_mat_defaultstyle_id_idx ON publishedinfos_mat ("defaultStyle.id");
+CREATE INDEX publishedinfos_mat_defaultstyle_name_idx ON publishedinfos_mat ("defaultStyle.name");
+CREATE INDEX publishedinfos_mat_defaultstyle_filename_idx ON publishedinfos_mat ("defaultStyle.filename");
+CREATE INDEX publishedinfos_mat_defaultstyle_format_idx ON publishedinfos_mat ("defaultStyle.format");
+CREATE INDEX publishedinfos_mat_workspace_id_not_null_idx ON publishedinfos_mat ("workspace.id") WHERE "workspace.id" IS NOT NULL;
+CREATE INDEX publishedinfos_mat_workspace_name_not_null_idx ON publishedinfos_mat ("workspace.name") WHERE "workspace.name" IS NOT NULL;
+CREATE INDEX publishedinfos_mat_styles_id_idx ON publishedinfos_mat USING GIN ("styles.id");
+CREATE INDEX publishedinfos_mat_layers_id_not_null_idx ON publishedinfos_mat USING GIN ("layers.id") WHERE "layers.id" IS NOT NULL;
+CREATE INDEX publishedinfos_mat_mode_not_null_idx ON publishedinfos_mat (mode) WHERE mode IS NOT NULL;
+
+-- Indexes for tilelayers_mat (8 indexes preserved)
+CREATE INDEX tilelayers_mat_id_idx ON tilelayers_mat ("id");
+CREATE INDEX tilelayers_mat_infotype_idx ON tilelayers_mat ("@type");
+CREATE INDEX tilelayers_mat_name_idx ON tilelayers_mat (name);
+CREATE INDEX tilelayers_mat_enabled_idx ON tilelayers_mat (enabled);
+CREATE INDEX tilelayers_mat_advertised_idx ON tilelayers_mat (advertised);
+CREATE INDEX tilelayers_mat_type_idx ON tilelayers_mat ("type");
+CREATE INDEX tilelayers_mat_workspace_name_idx ON tilelayers_mat ("workspace.name");
+CREATE INDEX tilelayers_mat_published_name_idx ON tilelayers_mat ("published.name");
+
+-- Shared function to sync publishedinfos_mat by IDs
+CREATE OR REPLACE FUNCTION sync_publishedinfos_by_ids(ids TEXT[]) RETURNS VOID AS
+$$
+BEGIN
+  INSERT INTO publishedinfos_mat
+  SELECT * FROM publishedinfos WHERE id = ANY(ids)
+  ON CONFLICT (id) DO UPDATE SET
+    (name, "prefixedName", title, enabled, advertised, "type", workspace, publishedinfo,
+     "styles.id", "resource.id", "resource.name", "resource.enabled", "resource.advertised",
+     "resource.SRS", "resource.store.id", "resource.store.name", "resource.store.enabled",
+     "resource.store.type", "resource.store.workspace.id", "resource.store.workspace.name",
+     "resource.namespace.id", "resource.namespace.prefix", "defaultStyle.id", "defaultStyle.name",
+     "defaultStyle.filename", "defaultStyle.format", resource, store, namespace, "defaultStyle",
+     mode, "workspace.id", "workspace.name", "layers.id")
+    = (EXCLUDED.name, EXCLUDED."prefixedName", EXCLUDED.title, EXCLUDED.enabled, EXCLUDED.advertised,
+       EXCLUDED."type", EXCLUDED.workspace, EXCLUDED.publishedinfo, EXCLUDED."styles.id",
+       EXCLUDED."resource.id", EXCLUDED."resource.name", EXCLUDED."resource.enabled",
+       EXCLUDED."resource.advertised", EXCLUDED."resource.SRS", EXCLUDED."resource.store.id",
+       EXCLUDED."resource.store.name", EXCLUDED."resource.store.enabled", EXCLUDED."resource.store.type",
+       EXCLUDED."resource.store.workspace.id", EXCLUDED."resource.store.workspace.name",
+       EXCLUDED."resource.namespace.id", EXCLUDED."resource.namespace.prefix", EXCLUDED."defaultStyle.id",
+       EXCLUDED."defaultStyle.name", EXCLUDED."defaultStyle.filename", EXCLUDED."defaultStyle.format",
+       EXCLUDED.resource, EXCLUDED.store, EXCLUDED.namespace, EXCLUDED."defaultStyle", EXCLUDED.mode,
+       EXCLUDED."workspace.id", EXCLUDED."workspace.name", EXCLUDED."layers.id");
+END
+$$ LANGUAGE plpgsql;
+
+-- Trigger function for layerinfo INSERT, UPDATE, DELETE
+CREATE OR REPLACE FUNCTION sync_layerinfo_to_publishedinfos_mat() RETURNS TRIGGER AS
+$$
+BEGIN
+  IF TG_OP = 'INSERT' OR TG_OP = 'UPDATE' THEN
+    PERFORM sync_publishedinfos_by_ids(ARRAY[NEW.id]);
+  ELSIF TG_OP = 'DELETE' THEN
+    DELETE FROM publishedinfos_mat WHERE id = OLD.id;
+  END IF;
+  RETURN NULL;
+END
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER layerinfo_sync_to_publishedinfos_mat
+  AFTER INSERT OR UPDATE OR DELETE ON layerinfo
+  FOR EACH ROW EXECUTE FUNCTION sync_layerinfo_to_publishedinfos_mat();
+
+-- Trigger function for layergroupinfo INSERT, UPDATE, DELETE
+CREATE OR REPLACE FUNCTION sync_layergroupinfo_to_publishedinfos_mat() RETURNS TRIGGER AS
+$$
+BEGIN
+  IF TG_OP = 'INSERT' OR TG_OP = 'UPDATE' THEN
+    PERFORM sync_publishedinfos_by_ids(ARRAY[NEW.id]);
+  ELSIF TG_OP = 'DELETE' THEN
+    DELETE FROM publishedinfos_mat WHERE id = OLD.id;
+  END IF;
+  RETURN NULL;
+END
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER layergroupinfo_sync_to_publishedinfos_mat
+  AFTER INSERT OR UPDATE OR DELETE ON layergroupinfo
+  FOR EACH ROW EXECUTE FUNCTION sync_layergroupinfo_to_publishedinfos_mat();
+
+-- Trigger function for workspaceinfo UPDATE
+CREATE OR REPLACE FUNCTION workspaceinfo_update_trigger() RETURNS TRIGGER AS
+$$
+DECLARE
+  affected_ids TEXT[];
+BEGIN
+  -- LayerGroupInfo IDs where workspace matches
+  SELECT array_agg(id) INTO affected_ids
+  FROM layergroupinfo WHERE workspace = NEW.id;
+  
+  -- LayerInfo IDs via resource.store.workspace
+  SELECT array_agg(l.id) INTO affected_ids
+  FROM layerinfo l
+  INNER JOIN resourceinfo r ON l.resource = r.id
+  INNER JOIN storeinfo s ON r.store = s.id
+  WHERE s.workspace = NEW.id;
+  
+  IF affected_ids IS NOT NULL THEN
+    PERFORM sync_publishedinfos_by_ids(affected_ids);
+  END IF;
+  RETURN NULL;
+END
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER workspaceinfo_update_trigger
+  AFTER UPDATE ON workspaceinfo
+  FOR EACH ROW EXECUTE FUNCTION workspaceinfo_update_trigger();
+
+-- Trigger function for namespaceinfo UPDATE
+CREATE OR REPLACE FUNCTION namespaceinfo_update_trigger() RETURNS TRIGGER AS
+$$
+DECLARE
+  affected_ids TEXT[];
+BEGIN
+  -- LayerInfo IDs via resource.namespace
+  SELECT array_agg(l.id) INTO affected_ids
+  FROM layerinfo l
+  INNER JOIN resourceinfo r ON l.resource = r.id
+  WHERE r.namespace = NEW.id;
+  
+  IF affected_ids IS NOT NULL THEN
+    PERFORM sync_publishedinfos_by_ids(affected_ids);
+  END IF;
+  RETURN NULL;
+END
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER namespaceinfo_update_trigger
+  AFTER UPDATE ON namespaceinfo
+  FOR EACH ROW EXECUTE FUNCTION namespaceinfo_update_trigger();
+
+-- Trigger function for storeinfo UPDATE
+CREATE OR REPLACE FUNCTION storeinfo_update_trigger() RETURNS TRIGGER AS
+$$
+DECLARE
+  affected_ids TEXT[];
+BEGIN
+  -- LayerInfo IDs via resource.store
+  SELECT array_agg(l.id) INTO affected_ids
+  FROM layerinfo l
+  INNER JOIN resourceinfo r ON l.resource = r.id
+  WHERE r.store = NEW.id;
+  
+  IF affected_ids IS NOT NULL THEN
+    PERFORM sync_publishedinfos_by_ids(affected_ids);
+  END IF;
+  RETURN NULL;
+END
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER storeinfo_update_trigger
+  AFTER UPDATE ON storeinfo
+  FOR EACH ROW EXECUTE FUNCTION storeinfo_update_trigger();
+
+-- Trigger function for resourceinfo UPDATE
+CREATE OR REPLACE FUNCTION resourceinfo_update_trigger() RETURNS TRIGGER AS
+$$
+DECLARE
+  affected_ids TEXT[];
+BEGIN
+  -- LayerInfo IDs where resource matches
+  SELECT array_agg(id) INTO affected_ids
+  FROM layerinfo WHERE resource = NEW.id;
+  
+  IF affected_ids IS NOT NULL THEN
+    PERFORM sync_publishedinfos_by_ids(affected_ids);
+  END IF;
+  RETURN NULL;
+END
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER resourceinfo_update_trigger
+  AFTER UPDATE ON resourceinfo
+  FOR EACH ROW EXECUTE FUNCTION resourceinfo_update_trigger();
+
+-- Trigger function for styleinfo UPDATE and DELETE
+CREATE OR REPLACE FUNCTION styleinfo_update_delete_trigger() RETURNS TRIGGER AS
+$$
+DECLARE
+  affected_ids TEXT[];
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    SELECT array_agg(id) INTO affected_ids
+    FROM layerinfo WHERE "defaultStyle" = OLD.id;
+  ELSE
+    SELECT array_agg(id) INTO affected_ids
+    FROM layerinfo WHERE "defaultStyle" = NEW.id;
+  END IF;
+  
+  IF affected_ids IS NOT NULL THEN
+    PERFORM sync_publishedinfos_by_ids(affected_ids);
+  END IF;
+  RETURN NULL;
+END
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER styleinfo_update_delete_trigger
+  AFTER UPDATE OR DELETE ON styleinfo
+  FOR EACH ROW EXECUTE FUNCTION styleinfo_update_delete_trigger();
+
+-- Trigger function to sync tilelayers_mat from publishedinfos_mat
+CREATE OR REPLACE FUNCTION sync_publishedinfos_mat_to_tilelayers_mat() RETURNS TRIGGER AS
+$$
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    IF EXISTS (SELECT 1 FROM publishedinfo WHERE id = NEW.id AND tilelayer IS NOT NULL) THEN
+      INSERT INTO tilelayers_mat
+      SELECT t.* FROM tilelayers t
+      INNER JOIN publishedinfos_mat p ON t.id = p.id
+      WHERE p.id = NEW.id
+      ON CONFLICT (id) DO UPDATE SET
+        (id, "@type", name, enabled, advertised, "type", "workspace.name", "published.name",
+         tilelayer, workspace, namespace, store, resource, publishedinfo, "defaultStyle")
+        = (EXCLUDED.id, EXCLUDED."@type", EXCLUDED.name, EXCLUDED.enabled, EXCLUDED.advertised,
+           EXCLUDED."type", EXCLUDED."workspace.name", EXCLUDED."published.name", EXCLUDED.tilelayer,
+           EXCLUDED.workspace, EXCLUDED.namespace, EXCLUDED.store, EXCLUDED.resource,
+           EXCLUDED.publishedinfo, EXCLUDED."defaultStyle");
+    END IF;
+  ELSIF TG_OP = 'UPDATE' THEN
+    IF EXISTS (SELECT 1 FROM publishedinfo WHERE id = NEW.id AND tilelayer IS NOT NULL) THEN
+      INSERT INTO tilelayers_mat
+      SELECT t.* FROM tilelayers t
+      INNER JOIN publishedinfos_mat p ON t.id = p.id
+      WHERE p.id = NEW.id
+      ON CONFLICT (id) DO UPDATE SET
+        (id, "@type", name, enabled, advertised, "type", "workspace.name", "published.name",
+         tilelayer, workspace, namespace, store, resource, publishedinfo, "defaultStyle")
+        = (EXCLUDED.id, EXCLUDED."@type", EXCLUDED.name, EXCLUDED.enabled, EXCLUDED.advertised,
+           EXCLUDED."type", EXCLUDED."workspace.name", EXCLUDED."published.name", EXCLUDED.tilelayer,
+           EXCLUDED.workspace, EXCLUDED.namespace, EXCLUDED.store, EXCLUDED.resource,
+           EXCLUDED.publishedinfo, EXCLUDED."defaultStyle");
+    ELSE
+      DELETE FROM tilelayers_mat WHERE id = NEW.id;
+    END IF;
+  ELSIF TG_OP = 'DELETE' THEN
+    DELETE FROM tilelayers_mat WHERE id = OLD.id;
+  END IF;
+  RETURN NULL;
+END
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER publishedinfos_mat_sync_to_tilelayers_mat
+  AFTER INSERT OR UPDATE OR DELETE ON publishedinfos_mat
+  FOR EACH ROW EXECUTE FUNCTION sync_publishedinfos_mat_to_tilelayers_mat();
+
+-- Drop unneeded indexes from publishedinfo, layerinfo, and layergroupinfo now that queries use publishedinfos_mat
+DROP INDEX IF EXISTS publishedinfo_enabled_idx;
+DROP INDEX IF EXISTS publishedinfo_advertised_idx;
+DROP INDEX IF EXISTS publishedinfo_info_idx;
+-- layerinfo indexes
+DROP INDEX IF EXISTS layerinfo_defaultstyle_idx;
+DROP INDEX IF EXISTS layerinfo_styles_gin_idx;
+-- layergroupinfo indexes
+DROP INDEX IF EXISTS layergroupinfo_enabled_idx;
+DROP INDEX IF EXISTS layergroupinfo_advertised_idx;
+DROP INDEX IF EXISTS layergroupinfo_layers_gin_idx;
+DROP INDEX IF EXISTS layergroupinfo_styles_gin_idx;

--- a/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/autoconfigure/catalog/backend/pgconfig/PgconfigMigrationAutoConfigurationTest.java
+++ b/src/catalog/backends/pgconfig/src/test/java/org/geoserver/cloud/autoconfigure/catalog/backend/pgconfig/PgconfigMigrationAutoConfigurationTest.java
@@ -114,7 +114,9 @@ class PgconfigMigrationAutoConfigurationTest {
                 "serviceinfo",
                 "logginginfo",
                 "resourcestore",
-                "resource_lock");
+                "resource_lock",
+                "publishedinfos_mat",
+                "tilelayers_mat");
         List<String> sequences = List.of("gs_update_sequence", "resourcestore_id_seq");
 
         Map<String, String> expected = new TreeMap<>();

--- a/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/CatalogInfoRepositoryHolderImpl.java
+++ b/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/CatalogInfoRepositoryHolderImpl.java
@@ -58,10 +58,11 @@ public class CatalogInfoRepositoryHolderImpl implements CatalogInfoRepositoryHol
     protected WorkspaceRepository workspaces;
     protected StoreRepository stores;
     protected ResourceRepository resources;
-    protected LayerRepository layers;
-    protected LayerGroupRepository layerGroups;
     protected StyleRepository styles;
     protected MapRepository maps;
+
+    protected LayerRepository layers;
+    protected LayerGroupRepository layerGroups;
 
     protected CatalogInfoTypeRegistry<CatalogInfoRepository<?>> repos = new CatalogInfoTypeRegistry<>();
 

--- a/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/Query.java
+++ b/src/catalog/plugin/src/main/java/org/geoserver/catalog/plugin/Query.java
@@ -240,4 +240,9 @@ public @Data class Query<T extends Info> {
     public Query<T> withFilter(Filter filter) {
         return filter.equals(this.filter) ? this : new Query<>(this).setFilter(filter);
     }
+
+    @SuppressWarnings("unchecked")
+    public <T extends CatalogInfo> Query<T> as() {
+        return (Query<T>) this;
+    }
 }

--- a/src/catalog/plugin/src/test/resources/logback-test.xml
+++ b/src/catalog/plugin/src/test/resources/logback-test.xml
@@ -13,4 +13,5 @@
     <logger name="org.springframework.boot.test" level="WARN"/>
     <logger name="org.geoserver.cloud.catalog.locking" level="INFO"/>
     <logger name="org.geoserver.catalog.impl" level="OFF"/>
+    <logger name="org.geoserver.cloud.backend.pgconfig.catalog.repository" level="DEBUG"/>
 </configuration>

--- a/src/gwc/backends/pgconfig/src/main/java/org/geoserver/cloud/gwc/backend/pgconfig/PgconfigTileLayerInfoRowMapper.java
+++ b/src/gwc/backends/pgconfig/src/main/java/org/geoserver/cloud/gwc/backend/pgconfig/PgconfigTileLayerInfoRowMapper.java
@@ -25,6 +25,26 @@ class PgconfigTileLayerInfoRowMapper implements RowMapper<TileLayerInfo> {
 
     protected static final ObjectMapper objectMapper = PgconfigObjectMapper.newObjectMapper();
 
+    /**
+     * Columns required to construct a tile layer
+     *
+     * <pre>{@code
+     *      Column     |   Type   |
+     * ----------------+----------+
+     *  &#64;type      | infotype |
+     *  workspace      | jsonb    |
+     *  namespace      | jsonb    |
+     *  store          | jsonb    |
+     *  resource       | jsonb    |
+     *  publishedinfo  | jsonb    |
+     *  defaultStyle   | jsonb    |
+     *  tilelayer      | jsonb    |
+     *
+     * }</pre>
+     */
+    static final String MAPPED_COLUMNS =
+            "\"@type\", tilelayer, workspace, namespace, store, resource, publishedinfo, \"defaultStyle\"";
+
     private final RowMapper<PublishedInfo> publishedMapper;
 
     private PgconfigTileLayerInfoRowMapper(RowMapper<PublishedInfo> publishedMapper) {

--- a/src/gwc/backends/pgconfig/src/main/java/org/geoserver/cloud/gwc/backend/pgconfig/PgconfigTileLayerInfoRowMapper.java
+++ b/src/gwc/backends/pgconfig/src/main/java/org/geoserver/cloud/gwc/backend/pgconfig/PgconfigTileLayerInfoRowMapper.java
@@ -33,7 +33,8 @@ class PgconfigTileLayerInfoRowMapper implements RowMapper<TileLayerInfo> {
 
     public static PgconfigTileLayerInfoRowMapper newInstance(@NonNull JdbcTemplate template) {
         PgconfigStyleRepository styleLoader = new PgconfigStyleRepository(template);
-        RowMapper<PublishedInfo> publishedMapper = CatalogInfoRowMapper.published(styleLoader::findById);
+        RowMapper<PublishedInfo> publishedMapper =
+                CatalogInfoRowMapper.<PublishedInfo>newInstance().setStyleLoader(styleLoader::findById);
         return new PgconfigTileLayerInfoRowMapper(publishedMapper);
     }
 


### PR DESCRIPTION
This commit enhances the PostgreSQL-based catalog backend (pgconfig) by introducing
a new PgconfigPublishedInfoRepository for querying PublishedInfo objects (LayerInfo
and LayerGroupInfo) directly from the database, leveraging the publishedinfos view.
It also adds materialized tables (publishedinfos_mat and tilelayers_mat) with
triggers to maintain real-time synchronization with CatalogInfo changes, improving
query performance.

Key changes:
- Java: Introduced PgconfigPublishedInfoRepository as a read-only repository for
  PublishedInfo, integrated into PgconfigCatalogFacade with type-safe repository
  lookup and query support. Updated PgconfigLayerRepository and
  PgconfigLayerGroupRepository to extend it, refining their query logic.
- SQL: Added V1_9_0__PublishedInfos_add_styles_id_and_layers_id.sql to enhance the
  publishedinfos view with styles.id and layers.id. Introduced
  V2_0_0__PublishedInfos_Materialized_Table.sql to create and index
  publishedinfos_mat and tilelayers_mat, with triggers for layerinfo,
  layergroupinfo, workspaceinfo, namespaceinfo, storeinfo, resourceinfo, and
  styleinfo updates.

The materialized tables use a trigger-based approach to ensure consistency,
syncing tilelayers_mat from publishedinfos_mat for scalability and maintenance
simplicity. Indexes optimize query performance, with partial indexes for
high-NULL columns. This supports the GeoServer Cloud goal of efficient catalog
access.

Tests updated to include new tables in PgconfigMigrationAutoConfigurationTest.